### PR TITLE
Added fluent stream - essentially cloned the logstash-adding code

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,31 @@ Usage:
 ```javascript
     var logging = require('service-logging'),
 		streams = require('service-logging-streams');
-	
+
 	logging({
-	
+
 		/* ... */
-		
+
 		streams: streams({
 			fileName: 'my_service.log' // defaults to 'test.log',
 			logstash: { // if not specified no logstash stream will be created
 				host: 'blah.com',
 				port: 1234
+			},
+			fluentd: { // if not specified no fluentd stream will be created
+				tag: 'development',
+				type: 'forward',
+				host: 'localhost',
+				port: 24224
 			}
 		}).concat(/* you could add other streams here */)
-		
+
 		/* ... */
-		
+
 	});
 ```
 
-Creates a local stream and (optionally) a logstash stream.
+Creates a local stream and (optionally) a logstash and/or fluentd stream.
 
 Local stream properties:
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var fs = require('fs'),
-	bunyanTcpStream = require('bunyan-logstash-tcp'),
-	prettify = require('./prettify');
+  fluentStream = require('effluent-logger'),
+  bunyanTcpStream = require('bunyan-logstash-tcp'),
+  prettify = require('./prettify');
 
 function fileStream(fileName) {
   var stream = fs.createWriteStream(fileName);
@@ -37,6 +38,13 @@ module.exports = function(opts) {
     streams.push({
       type: 'raw',
       stream: bunyanTcpStream.createStream(opts.logstash)
+    });
+  }
+
+  if (opts.fluentd) {
+    streams.push({
+      type: 'raw',
+      stream: new fluentStream(opts.fluentd)
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "bunyan": "^1.4.0",
     "bunyan-logstash-tcp": "^0.3.4",
-    "bunyan-prettystream": "^0.1.3"
+    "bunyan-prettystream": "^0.1.3",
+    "effluent-logger": "git+https://github.com/oosidat/effluent-logger.git"
   },
   "devDependencies": {
     "jscs": "^1.13.1",


### PR DESCRIPTION
Pointed at fork of my version of the effluent-logger because we need the data object to be wrapped in a key-value object where key is "log" and value is the current data object

Also, should prolly be version bumped once this gets merged
